### PR TITLE
RFC: use REPL.REPLCompletions as completions provider instead/in addition to current method

### DIFF
--- a/JuliaSnail.jl
+++ b/JuliaSnail.jl
@@ -296,13 +296,15 @@ function apropos(ns, pattern)
    return res
 end
 
-### -- code completion using REPL completion
-
+"""
+    replcompletion(identifier,mod)
+Code completion suggestions for completion string `identifier` in module `mod`.
+Completions are provided by the built-in REPL.REPLCompletions.
+"""
 function replcompletion(identifier,mod)
     cs,_,_ = REPLCompletions.completions(identifier, length(identifier), mod)
     return REPLCompletions.completion_text.(cs)
 end
-
 
 ### --- server code
 

--- a/JuliaSnail.jl
+++ b/JuliaSnail.jl
@@ -300,7 +300,7 @@ end
 
 function replcompletion(identifier, pos, mod)
     cs,_,_ = REPLCompletions.completions(identifier,pos,mod)
-    return join(REPLCompletions.completion_text.(cs),",")
+    return REPLCompletions.completion_text.(cs)
 end
 
 

--- a/JuliaSnail.jl
+++ b/JuliaSnail.jl
@@ -20,6 +20,7 @@ module JuliaSnail
 import Markdown
 import Printf
 import Sockets
+import REPL.REPLCompletions
 
 
 export start, stop
@@ -293,6 +294,13 @@ function apropos(ns, pattern)
       append!(res, lsdefinitions(name_ns, name_n))
    end
    return res
+end
+
+### -- code completion using REPL completion
+
+function replcompletion(identifier, pos, mod)
+    cs,_,_ = REPLCompletions.completions(identifier,pos,mod)
+    return join(REPLCompletions.completion_text.(cs),",")
 end
 
 

--- a/JuliaSnail.jl
+++ b/JuliaSnail.jl
@@ -298,8 +298,8 @@ end
 
 ### -- code completion using REPL completion
 
-function replcompletion(identifier, pos, mod)
-    cs,_,_ = REPLCompletions.completions(identifier,pos,mod)
+function replcompletion(identifier,mod)
+    cs,_,_ = REPLCompletions.completions(identifier, length(identifier), mod)
     return REPLCompletions.completion_text.(cs)
 end
 

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -773,8 +773,7 @@ Julia include on the tmpfile, and then deleting the file."
        :Main
        (format "try; JuliaSnail.replcompletion(\"%1$s\", %2$s); catch; JuliaSnail.replcompletion(\"%1$s\", Main); end"
                identifier
-               (s-join "." module)
-               )
+               (s-join "." module))
        :async nil)))
 
 (defun julia-snail-repl-completion-at-point ()
@@ -783,7 +782,7 @@ Julia include on the tmpfile, and then deleting the file."
         (bounds (julia-snail--identifier-at-point-bounds))
         (split-on "\\.")
         (prefix "")
-        start pos)
+        start)
     (when bounds
       ;; Check for leading "\" (for latex symbol completions), we need to add an extra "\\" to
       ;; make sure that the string which arrives to the completion provider on the server starts with "\\".
@@ -793,8 +792,7 @@ Julia include on the tmpfile, and then deleting the file."
       ;; we get path completion.
       (when (s-equals-p (buffer-substring-no-properties (- (car bounds) 1) (car bounds)) "\"")
         (setq identifier (s-concat "\\\"" identifier))
-        (setq split-on "/")
-        )
+        (setq split-on "/"))
       ;; we want the string starting point passed to `completion-at-point' to be after
       ;; the last "." in `identifier' so that completions of the form Module.f ->
       ;; Module.func work (since `julia-snail--repl-completions' will return only "func" in

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -755,6 +755,33 @@ Julia include on the tmpfile, and then deleting the file."
        (format "Main.JuliaSnail.lsnames(%s, all=true, imported=true, include_modules=true, recursive=true)" ns)
        :async nil))))
 
+;; (defun julia-snail-completion-at-point ()
+;;   "Implementation for Emacs `completion-at-point' system."
+;;   (let ((identifier (julia-snail--identifier-at-point))
+;;         (bounds (julia-snail--identifier-at-point-bounds)))
+;;     (when bounds
+;;       (list (car bounds)
+;;             (cdr bounds)
+;;             (completion-table-dynamic
+;;              (lambda (_) (julia-snail--completions identifier)))
+;;             :exclusive 'yes))))
+
+;;TODO: need to handle the case where the module at point is not defined
+;; not sure if it is better to do so from the elisp side or from the server
+;; side
+(defun julia-snail--repl-completions (identifier)
+  (let* ((module (julia-snail--module-at-point)))
+    (let ((comp (split-string
+                 (julia-snail--send-to-server
+                   :Main
+                   (format "JuliaSnail.replcompletion(\"%s\", %d, %s)"
+                           identifier
+                           (length identifier)
+                           (car module))
+                   :async nil)
+                 ",")))
+      comp)))
+
 (defun julia-snail-completion-at-point ()
   "Implementation for Emacs `completion-at-point' system."
   (let ((identifier (julia-snail--identifier-at-point))
@@ -763,8 +790,10 @@ Julia include on the tmpfile, and then deleting the file."
       (list (car bounds)
             (cdr bounds)
             (completion-table-dynamic
-             (lambda (_) (julia-snail--completions identifier)))
+             (lambda (_) (julia-snail--repl-completions identifier)))
             :exclusive 'yes))))
+
+
 
 
 ;;; --- eldoc implementation

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -757,7 +757,6 @@ Julia include on the tmpfile, and then deleting the file."
 
 (defun julia-snail--repl-completions (identifier)
   (let* ((module (julia-snail--module-at-point)))
-    (split-string
      (julia-snail--send-to-server
        :Main
        (format "try; JuliaSnail.replcompletion(\"%s\", %d, %s); catch; JuliaSnail.replcompletion(\"%s\", %d, Main); end"
@@ -766,8 +765,7 @@ Julia include on the tmpfile, and then deleting the file."
                (s-join "." module)
                identifier
                (length identifier))
-       :async nil)
-     ",")))
+       :async nil)))
 
 (defun julia-snail-completion-at-point ()
   "Implementation for Emacs `completion-at-point' system."

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -755,17 +755,6 @@ Julia include on the tmpfile, and then deleting the file."
        (format "Main.JuliaSnail.lsnames(%s, all=true, imported=true, include_modules=true, recursive=true)" ns)
        :async nil))))
 
-;; (defun julia-snail-completion-at-point ()
-;;   "Implementation for Emacs `completion-at-point' system."
-;;   (let ((identifier (julia-snail--identifier-at-point))
-;;         (bounds (julia-snail--identifier-at-point-bounds)))
-;;     (when bounds
-;;       (list (car bounds)
-;;             (cdr bounds)
-;;             (completion-table-dynamic
-;;              (lambda (_) (julia-snail--completions identifier)))
-;;             :exclusive 'yes))))
-
 (defun julia-snail--repl-completions (identifier)
   (let* ((module (julia-snail--module-at-point)))
     (split-string
@@ -780,23 +769,20 @@ Julia include on the tmpfile, and then deleting the file."
        :async nil)
      ",")))
 
-;;TODO: how to add support for the case Module.f -> Module.func?
-;; seems that this is currently not working because REPLCompletions will return only the completion
-;; strings after the dot (e.g. "func"), and completion-at-point seems to filter this out because it expects
-;; to find a match for "Module.f" (if I understand correctly)
 (defun julia-snail-completion-at-point ()
   "Implementation for Emacs `completion-at-point' system."
   (let ((identifier (julia-snail--identifier-at-point))
         (bounds (julia-snail--identifier-at-point-bounds)))
     (when bounds
-      (list (car bounds)
+      ;; we want the string starting point passed to `completion-at-point' to be after
+      ;; the last "." in `identifier' so that completions of the form Module.f ->
+      ;; Module.func work (since `julia-snail--repl-completions' will return only "func" in
+      ;; this case)
+      (list (- (cdr bounds) (length (car (last (s-split "\\." identifier)))))
             (cdr bounds)
             (completion-table-dynamic
              (lambda (_) (julia-snail--repl-completions identifier)))
             :exclusive 'yes))))
-
-
-
 
 ;;; --- eldoc implementation
 


### PR DESCRIPTION
I have been playing around with replacing the current completion mechanism with the built-in `REPL.REPLCompletions` . (I thought about doing so after seeing this [closed PR](https://github.com/JuliaEditorSupport/julia-emacs/pull/106/commits/d93361de01f0a5826fdabf167d523b125138864b) in julia-emacs).

My motivation to try this came from two problems I saw with the current method:

1. It seems to suggest a lot of completions which are not really available in the current scope. 
For example for `prin` with the current method I get a long list of suggestions with most of them irrelevant (unavailable in current scope) such as `print_array, print_matrix, print_quoted,...` (those seem to be unexported methods from Base). 
 
2. Another problem is that the current method might not be able to provide completion when some macros are involved. Admittingly I have only one example, but it is a macro I use all the time so I want to make it work :) 
Considering the code below. With the current method, the completion I get for `MyS` is `@pack_MyStruct, @unpack_MyStruct`. 

```julia
using Parameters
@with_kw struct MyStruct
    x
end
```

Both of these issues seem to be solved when using `REPL.REPLCompletions` as the completions provider. But I guess they could also be solved within the current implementation (at least issue 1, not sure about issue 2). 

A disadvantage of REPLCompletions is that it doesn't allow fuzzy search. So maybe it is also possible to generate a combined completion list using the current method and `REPL.REPLCompletions` if fuzzy search is desired. 

Let me know what you think about this suggestion.