### PR TITLE
ignore `$` in julia-snail--identifier-at-point

### DIFF
--- a/julia-snail.el
+++ b/julia-snail.el
@@ -231,6 +231,7 @@ MODULE can be:
        (modify-syntax-entry ?. "_")
        (modify-syntax-entry ?@ "_")
        (modify-syntax-entry ?= " ")
+       (modify-syntax-entry ?$ " ")
        ,@body)))
 
 (defun julia-snail--bslash-before-p (pos)


### PR DESCRIPTION
This is a small fix to prevent `julia-snail--identifier-at-point` from capturing `$`.
If the `$` is captured it breaks `julia-snail--repl-completions` because it will send a command of the form:
```
"JuliaSnail.replcompletion(\"$identifier\",ModuleName)"
```
and Julia will try to interpolate the variable `identifier`, which is of course undefined. 

One could also escape the $ in the command sent, but since I don't think it can be a part of a name of a valid symbol I think we can just ignore it. 