### PR TITLE
Add smart send to repl function

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The `julia-snail-mode` minor mode provides a key binding map (`julia-snail-mode-
 | C-M-x   | julia-snail-send-top-level-form | ditto                                                    |
 | C-c C-r | julia-snail-send-region         | evaluate active region in the current module (or in `Main` with prefix arg)   |
 | C-c C-l | julia-snail-send-line           | copy current line directly to REPL                       |
-| C-x C-e | julia-snail-eval-region-or-block-or-line | copy current region, block, or line to REPL     |
+| C-c C-e | julia-snail-eval-region-or-block-or-line | copy current region, block, or line to REPL     |
 | C-c C-k | julia-snail-send-buffer-file    | `include()` the current buffer’s file                    |
 | C-c C-R | julia-snail-update-module-cache | update module-nested `include` cache (mainly for Revise) |
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The `julia-snail-mode` minor mode provides a key binding map (`julia-snail-mode-
 | C-M-x   | julia-snail-send-top-level-form | ditto                                                    |
 | C-c C-r | julia-snail-send-region         | evaluate active region in the current module (or in `Main` with prefix arg)   |
 | C-c C-l | julia-snail-send-line           | copy current line directly to REPL                       |
+| C-x C-e | julia-snail-eval-region-or-block-or-line | copy current region, block, or line to REPL     |
 | C-c C-k | julia-snail-send-buffer-file    | `include()` the current buffer’s file                    |
 | C-c C-R | julia-snail-update-module-cache | update module-nested `include` cache (mainly for Revise) |
 

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -982,6 +982,7 @@ autocompletion aware of the available modules."
     (define-key map (kbd "C-M-x") #'julia-snail-send-top-level-form)
     (define-key map (kbd "C-c C-r") #'julia-snail-send-region)
     (define-key map (kbd "C-c C-l") #'julia-snail-send-line)
+    (define-key map (kbd "C-x C-e") #'julia-snail-eval-region-or-block-or-line)
     (define-key map (kbd "C-c C-k") #'julia-snail-send-buffer-file)
     (define-key map (kbd "C-c C-m u") #'julia-snail-update-module-cache)
     map))

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -824,9 +824,8 @@ This is not module-context aware."
                  (block-description (plist-get q :block))
                  (block-start (-second-item block-description))
                  (block-end (-third-item block-description)))
-            ;; block fails, so send line
             (setq str (buffer-substring-no-properties block-start block-end)))
-        (user-error    
+        (user-error ; block fails, so send line    
          (setq str (buffer-substring-no-properties (point-at-bol) (point-at-eol))))))
     (julia-snail--send-to-repl str)))
 

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -981,7 +981,7 @@ autocompletion aware of the available modules."
     (define-key map (kbd "C-M-x") #'julia-snail-send-top-level-form)
     (define-key map (kbd "C-c C-r") #'julia-snail-send-region)
     (define-key map (kbd "C-c C-l") #'julia-snail-send-line)
-    (define-key map (kbd "C-x C-e") #'julia-snail-eval-region-or-block-or-line)
+    (define-key map (kbd "C-c C-e") #'julia-snail-eval-region-or-block-or-line)
     (define-key map (kbd "C-c C-k") #'julia-snail-send-buffer-file)
     (define-key map (kbd "C-c C-m u") #'julia-snail-update-module-cache)
     map))


### PR DESCRIPTION
I was using ess, and they have `ess-eval-region-or-function-or-paragraph-and-step` which is much simpler for one key-bind.
This PR would add:
`julia-snail-eval-region-or-block-or-line` binds to `"C-c C-e"`