### PR TITLE
Support Docker using docker-tramp

### DIFF
--- a/JuliaSnail.jl
+++ b/JuliaSnail.jl
@@ -667,9 +667,9 @@ Standard output and standard error during evaluation go into the REPL. Errors
 during evaluation are captured and sent back to the client as Elisp
 s-expressions. Special queries also write back their responses as s-expressions.
 """
-function start(port=10011)
+function start(port=10011; addr="127.0.0.1")
    global running = false
-   global server_socket = Sockets.listen(port)
+   global server_socket = Sockets.listen(Sockets.IPv4(addr), port)
    let wait_result = timedwait(function(); server_socket.status == Base.StatusActive; end,
                                5.0)
       if :timedout == wait_result

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -67,6 +67,13 @@
                  (repeat :tag "List of strings" string)))
 (make-variable-buffer-local 'julia-snail-extra-args)
 
+(defcustom julia-snail-host "127.0.0.1"
+  "Default Snail server ip to listen on."
+  :tag "Snail server port (local)"
+  :group 'julia-snail
+  :safe 'integerp
+  :type 'string)
+
 (defcustom julia-snail-port 10011
   "Default Snail server port for Emacs to connect to."
   :tag "Snail server port (local)"
@@ -492,7 +499,7 @@ returns \"/home/username/file.jl\"."
           (user-error "The vterm buffer is inactive; double-check julia-snail-executable path"))
         ;; now try to send the Snail startup command
         (julia-snail--send-to-repl
-          (format "JuliaSnail.start(%d); # please wait, time-to-first-plot..." (or julia-snail-remote-port julia-snail-port))
+          (format "JuliaSnail.start(%d; addr=\"%s\"); # please wait, time-to-first-plot..." (or julia-snail-remote-port julia-snail-port) julia-snail-host)
           :repl-buf repl-buf
           ;; wait a while in case dependencies need to be downloaded
           :polling-timeout (* 5 60 1000)


### PR DESCRIPTION
for #65 .
In the docker container, the listen address should be 0.0.0.0, not localhost, or port can not be published.