### PR TITLE
use `:toplevel` in `eval_in_module`

### DIFF
--- a/JuliaSnail.jl
+++ b/JuliaSnail.jl
@@ -153,6 +153,9 @@ function eval_in_module(fully_qualified_module_name::Array{Symbol}, expr::Expr)
    # dependencies are not necessarily loaded into Main, and so must be found
    # using another mechanism, i.e., the Base.root_module trick.
    # https://discourse.julialang.org/t/resolving-a-module-by-its-name/30569/6
+   if expr.head == :block
+      expr.head = :toplevel
+   end
    root = first(fully_qualified_module_name)
    fqm = try
       getfield(Main, root)


### PR DESCRIPTION
Before this change, if you did
```julia
macro foo(ex)
    @show ex
end

@foo 1
```
and tried to eval all of that in module using `julia-snail-send-region` or whatever, you'd get an error saying that `@foo` is not defined. This change makes it so that julia will first define the macro **before** trying to expand the macro. This also fixes the same issue if you tried loading a macro from a package in the same code unit that you try to use that macro in. 