### PR TITLE
ob-julia extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ This extension provides access Julia REPL history from `julia-snail-mode` buffer
 This extension uses [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl) to modify source buffer text (the letters in the key sequences stand for **j**ulia **f**ormatter):
 
 - `julia-snail/formatter-format-region` modifies the current region (<kbd>C-c j f r</kbd>)
-- `julia-snail/formatter-format-buffer` modifies the entire current buffer (<kbd>C-c j f b</kbd)
+- `julia-snail/formatter-format-buffer` modifies the entire current buffer (<kbd>C-c j f b</kbd>)
 
 ### Ob-Julia
 

--- a/README.md
+++ b/README.md
@@ -367,8 +367,11 @@ This extension provides access Julia REPL history from `julia-snail-mode` buffer
 This extension uses [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl) to modify source buffer text (the letters in the key sequences stand for **j**ulia **f**ormatter):
 
 - `julia-snail/formatter-format-region` modifies the current region (<kbd>C-c j f r</kbd>)
-- `julia-snail/formatter-format-buffer` modifies the entire current buffer (<kbd>C-c j f b</kbd>)
+- `julia-snail/formatter-format-buffer` modifies the entire current buffer (<kbd>C-c j f b</kbd>**
 
+### Ob-Julia
+
+This extension lets `julia-snail` be used in [Org Mode](https://orgmode.org/) src blocks. This implementation does not closely observe the usual functional conventions of org babel langauges, and instead more closely mirrors [emacs-jupyter's behaviour](https://github.com/nnicandro/emacs-jupyter). This mode is not very mature yet, but it *does* support rich multimedia display of images and plots, and also allows one to choose the evaluation module with a `:module` session parameter (default is `Main`).
 
 ## Future improvements
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Refer to the [changelog](https://github.com/gcv/julia-snail/blob/master/CHANGELO
 - [Extensions](#extensions)
     - [REPL history](#repl-history)
     - [Formatter](#formatter)
+	- [Ob-Julia](#ob-julia)
 - [Future improvements](#future-improvements)
 <!-- markdown-toc end -->
 

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ This extension provides access Julia REPL history from `julia-snail-mode` buffer
 This extension uses [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl) to modify source buffer text (the letters in the key sequences stand for **j**ulia **f**ormatter):
 
 - `julia-snail/formatter-format-region` modifies the current region (<kbd>C-c j f r</kbd>)
-- `julia-snail/formatter-format-buffer` modifies the entire current buffer (<kbd>C-c j f b</kbd>**
+- `julia-snail/formatter-format-buffer` modifies the entire current buffer (<kbd>C-c j f b</kbd)
 
 ### Ob-Julia
 

--- a/extensions/ob-julia/ObJulia.jl
+++ b/extensions/ob-julia/ObJulia.jl
@@ -1,0 +1,30 @@
+module ObJulia
+
+function babel_run_and_store(src_file, out_file)
+    open(out_file, "w+") do io
+        redirect_stdio(stdout=io, stderr=io) do
+            result = try
+                include(src_file)
+            catch err;
+                Base.display_error(IOContext(stdout, :color => true), err, Base.catch_backtrace())
+            end
+            Base.invokelatest() do 
+                for (imgtype, ext) ∈ [("image/png", ".png"), ("image/svg+xml", ".svg")]
+                    if showable(imgtype, result)
+                        tmp = tempname() * ext
+                        open(tmp, "w+") do io
+                            show(io, imgtype, result) # Save the image to disk
+                        end
+                        println(io, "[[file:$tmp]]") # print out an org-link to the saved image
+                        result = nothing 
+                    end
+                end
+                isnothing(result) || show(IOContext(stdout, :limit => true, :module => Main), "text/plain", result)
+            end 
+        end
+    end
+    println("\n", read(out_file, String))
+end
+
+
+end 

--- a/extensions/ob-julia/ObJulia.jl
+++ b/extensions/ob-julia/ObJulia.jl
@@ -1,13 +1,18 @@
 module ObJulia
 
-function babel_run_and_store(mod::Module, src_file, out_file)
+function babel_run_and_store(mod::Module, src_file, out_file, use_error_pane::Bool)
     open(out_file, "w+") do _io
         io = IOContext(_io, :limit => true, :module => mod, :color => true)
         redirect_stdio(stdout=io, stderr=io) do
             result = try
                 Core.include(mod, src_file)
             catch err;
-                Base.display_error(io, err, Base.catch_backtrace())
+                if use_error_pane
+                    flush(_io)
+                    rethrow()
+                else
+                    Base.display_error(io, err, Base.catch_backtrace())
+                end 
             end
             Base.invokelatest() do 
                 for (imgtype, ext) ∈ [("image/png", ".png"), ("image/svg+xml", ".svg")]

--- a/extensions/ob-julia/ObJulia.jl
+++ b/extensions/ob-julia/ObJulia.jl
@@ -1,10 +1,10 @@
 module ObJulia
 
-function babel_run_and_store(src_file, out_file)
+function babel_run_and_store(mod::Module, src_file, out_file)
     open(out_file, "w+") do io
         redirect_stdio(stdout=io, stderr=io) do
             result = try
-                include(src_file)
+                Core.include(mod, src_file)
             catch err;
                 Base.display_error(IOContext(stdout, :color => true), err, Base.catch_backtrace())
             end
@@ -27,4 +27,4 @@ function babel_run_and_store(src_file, out_file)
 end
 
 
-end 
+end

--- a/extensions/ob-julia/ObJulia.jl
+++ b/extensions/ob-julia/ObJulia.jl
@@ -1,12 +1,13 @@
 module ObJulia
 
 function babel_run_and_store(mod::Module, src_file, out_file)
-    open(out_file, "w+") do io
+    open(out_file, "w+") do _io
+        io = IOContext(_io, :limit => true, :module => mod, :color => true)
         redirect_stdio(stdout=io, stderr=io) do
             result = try
                 Core.include(mod, src_file)
             catch err;
-                Base.display_error(IOContext(stdout, :color => true), err, Base.catch_backtrace())
+                Base.display_error(io, err, Base.catch_backtrace())
             end
             Base.invokelatest() do 
                 for (imgtype, ext) ∈ [("image/png", ".png"), ("image/svg+xml", ".svg")]
@@ -19,11 +20,12 @@ function babel_run_and_store(mod::Module, src_file, out_file)
                         result = nothing 
                     end
                 end
-                isnothing(result) || show(IOContext(stdout, :limit => true, :module => Main), "text/plain", result)
+                isnothing(result) || show(io, "text/plain", result)
             end 
         end
     end
-    println("\n", read(out_file, String))
+    println()
+    @info "ob-julia evaluated\n"*read(out_file, String)
 end
 
 

--- a/extensions/ob-julia/ObJulia.jl
+++ b/extensions/ob-julia/ObJulia.jl
@@ -25,7 +25,7 @@ function babel_run_and_store(mod::Module, src_file, out_file)
         end
     end
     println()
-    @info "ob-julia evaluated\n"*read(out_file, String)
+    @info "ob-julia evaluated in module $mod\n"*read(out_file, String)
 end
 
 

--- a/extensions/ob-julia/ob-julia.el
+++ b/extensions/ob-julia/ob-julia.el
@@ -1,0 +1,44 @@
+;;; ob-julia.el --- Julia Snail -*- lexical-binding: t -*-
+
+;;; --- requirements
+
+(require 'julia-snail)
+
+(defun julia-snail/ob-julia-evaluate (body src-file out-file)
+  (let* ((filename (julia-snail--efn (buffer-file-name (buffer-base-buffer))))
+         (module :Main)
+         (line-num 0)
+		 (text (format "JuliaSnail.Extensions.ObJulia.babel_run_and_store(\"%s\", \"%s\")" src-file out-file)))
+    ;; (julia-snail--send-to-repl text)
+	(julia-snail--send-to-server :Main text)))
+
+(defun org-babel-execute:julia (body params)
+  (let ((src-file (org-babel-temp-file "julia-src-"))
+		(out-file (org-babel-temp-file "julia-out-")))
+	(with-temp-file src-file (insert body))
+	(julia-snail/ob-julia-evaluate body src-file out-file)
+	(let ((c 0))
+      (while (and (< c 100) (= 0 (file-attribute-size (file-attributes out-file))))
+		(sit-for 0.1)
+		(setq c (1+ c))))
+    (with-temp-buffer
+      (insert-file-contents out-file)
+      (let ((bs (buffer-string)))
+		(if (catch 'loop
+			  (dolist (line (split-string bs "\n"))
+				(if (> (length line) 12000)
+					(throw 'loop t))))
+			"Output suppressed (line too long)"
+		  bs)))))
+
+(defun julia-snail/ob-julia-init (repl-buf)
+  (julia-snail--send-to-server
+    '("JuliaSnail" "Extensions")
+    "load([\"ob-julia\" \"ObJulia.jl\"])"
+    :repl-buf repl-buf
+    :async nil))
+
+
+(provide 'julia-snail/ob-julia)
+
+;;; repl-history.el ends here

--- a/extensions/ob-julia/ob-julia.el
+++ b/extensions/ob-julia/ob-julia.el
@@ -1,24 +1,58 @@
 ;;; ob-julia.el --- Julia Snail -*- lexical-binding: t -*-
 
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; A Julia Snail extension to work with Org Babel
+
+
 ;;; --- requirements
 
 (require 'julia-snail)
 
+;; Customization
 (defvar org-babel-default-header-args:julia '((:wrap)
 											  (:module . "Main")))
+
+(defcustom julia-snail/ob-julia-use-error-pane t
+  "If true, use julia-snail's popup error pane. Otherwise, display errors inline"
+  :tag "Control the behaviour of errors thrown during Julia evaulation"
+  :group 'julia-snail
+  :safe 'booleanp
+  :type 'boolean)
+
 
 (defun julia-snail/ob-julia-evaluate (module body src-file out-file)
   (let* ((filename (julia-snail--efn (buffer-file-name (buffer-base-buffer))))
          (line-num 0)
-		 (text (format "JuliaSnail.Extensions.ObJulia.babel_run_and_store(%s, \"%s\", \"%s\")" module src-file out-file)))
-    ;; (julia-snail--send-to-repl text)
+		 (text (format "JuliaSnail.Extensions.ObJulia.babel_run_and_store(%s, \"%s\", \"%s\", %s)"
+					   module
+					   src-file
+					   out-file
+					   (if julia-snail/ob-julia-use-error-pane "true" "false"))))
+    ;; This code was meant to startup julia-snail in the org buffer if it's not active, but caused an error
+	;; in org-mode on showing the first result of evalutation. Not sure why.
 	;; (unless (get-buffer julia-snail-repl-buffer)
 	;;   (progn
 	;; 	(julia-snail) t))
 	(julia-snail--send-to-server :Main text)))
 
+;; This function was adapted from ob-julia-vterm by Shigeaki Nishina (GPL-v3)
+;; https://github.com/shg/ob-julia-vterm.el as of April 14, 2022
 (defun org-babel-execute:julia (body params)
-  (let ((src-file (org-babel-temp-file "julia-src-"))
+  (let ((src-file (concat (org-babel-temp-file "julia-src-") ".jl"))
 		(out-file (org-babel-temp-file "julia-out-"))
 		(module (let ((maybe-module (cdr (assq :module params))))
 				  (if maybe-module maybe-module "Main"))))
@@ -47,5 +81,3 @@
 
 (provide 'julia-snail/ob-julia)
 ;;; ob-julia.el ends here
-
-(if nil "bye" "lie")

--- a/extensions/ob-julia/ob-julia.el
+++ b/extensions/ob-julia/ob-julia.el
@@ -20,7 +20,8 @@
 (defun org-babel-execute:julia (body params)
   (let ((src-file (org-babel-temp-file "julia-src-"))
 		(out-file (org-babel-temp-file "julia-out-"))
-		(module (cdr (assq :module params))))
+		(module (let (maybe-module (cdr (assq :module params)))
+					(if maybe-module maybe-module "Main"))))
 	(with-temp-file src-file (insert body))
 	(julia-snail/ob-julia-evaluate module body src-file out-file)
 	(let ((c 0))
@@ -47,3 +48,5 @@
 
 (provide 'julia-snail/ob-julia)
 ;;; ob-julia.el ends here
+
+(if nil "bye" "lie")

--- a/extensions/ob-julia/ob-julia.el
+++ b/extensions/ob-julia/ob-julia.el
@@ -20,8 +20,8 @@
 (defun org-babel-execute:julia (body params)
   (let ((src-file (org-babel-temp-file "julia-src-"))
 		(out-file (org-babel-temp-file "julia-out-"))
-		(module (let (maybe-module (cdr (assq :module params)))
-					(if maybe-module maybe-module "Main"))))
+		(module (let ((maybe-module (cdr (assq :module params))))
+				  (if maybe-module maybe-module "Main"))))
 	(with-temp-file src-file (insert body))
 	(julia-snail/ob-julia-evaluate module body src-file out-file)
 	(let ((c 0))
@@ -44,7 +44,6 @@
     "load([\"ob-julia\" \"ObJulia.jl\"])"
     :repl-buf repl-buf
     :async nil))
-
 
 (provide 'julia-snail/ob-julia)
 ;;; ob-julia.el ends here

--- a/extensions/ob-julia/ob-julia.el
+++ b/extensions/ob-julia/ob-julia.el
@@ -4,19 +4,25 @@
 
 (require 'julia-snail)
 
-(defun julia-snail/ob-julia-evaluate (body src-file out-file)
+(defvar org-babel-default-header-args:julia '((:wrap)
+											  (:module . "Main")))
+
+(defun julia-snail/ob-julia-evaluate (module body src-file out-file)
   (let* ((filename (julia-snail--efn (buffer-file-name (buffer-base-buffer))))
-         (module :Main)
          (line-num 0)
-		 (text (format "JuliaSnail.Extensions.ObJulia.babel_run_and_store(\"%s\", \"%s\")" src-file out-file)))
+		 (text (format "JuliaSnail.Extensions.ObJulia.babel_run_and_store(%s, \"%s\", \"%s\")" module src-file out-file)))
     ;; (julia-snail--send-to-repl text)
+	;; (unless (get-buffer julia-snail-repl-buffer)
+	;;   (progn
+	;; 	(julia-snail) t))
 	(julia-snail--send-to-server :Main text)))
 
 (defun org-babel-execute:julia (body params)
   (let ((src-file (org-babel-temp-file "julia-src-"))
-		(out-file (org-babel-temp-file "julia-out-")))
+		(out-file (org-babel-temp-file "julia-out-"))
+		(module (cdr (assq :module params))))
 	(with-temp-file src-file (insert body))
-	(julia-snail/ob-julia-evaluate body src-file out-file)
+	(julia-snail/ob-julia-evaluate module body src-file out-file)
 	(let ((c 0))
       (while (and (< c 100) (= 0 (file-attribute-size (file-attributes out-file))))
 		(sit-for 0.1)
@@ -40,5 +46,4 @@
 
 
 (provide 'julia-snail/ob-julia)
-
-;;; repl-history.el ends here
+;;; ob-julia.el ends here


### PR DESCRIPTION
I whipped up a quick `ob-julia` extension that I think for now is good enough for my personal uses.  This allows one to use a `julia-snail` process to evaluate code in emacs Org Mode SRC blocks. Here's a little demo video of it in action:

https://user-images.githubusercontent.com/29157027/163515735-1f8fabcc-eb13-49da-8616-213c91ec18d2.mp4


No big deal if you don't want this or want something to be changed, I just figured I'd open this PR in case you think this is worth having in this repo, otherwise it can continue to live in my fork. 