### PR TITLE
Get completion working in org babel src blocks

### DIFF
--- a/extensions/ob-julia/ObJulia.jl
+++ b/extensions/ob-julia/ObJulia.jl
@@ -13,7 +13,7 @@
 
 module ObJulia
 
-function babel_run_and_store(mod::Module, src_file, out_file, use_error_pane::Bool)
+function babel_run_and_store(mod::Module, src_file, out_file, use_error_pane::Bool, mirror_to_repl::Bool)
     open(out_file, "w+") do _io
         io = IOContext(_io, :limit => true, :module => mod, :color => true)
         redirect_stdio(stdout=io, stderr=io) do
@@ -42,8 +42,10 @@ function babel_run_and_store(mod::Module, src_file, out_file, use_error_pane::Bo
             end
         end
     end
-    println()
-    @info "ob-julia evaluated in module $mod\n"*read(out_file, String)
+    if mirror_to_repl
+        println()
+        @info "ob-julia evaluated in module $mod\n"*read(out_file, String)
+    end
 end
 
 end

--- a/extensions/ob-julia/ob-julia.el
+++ b/extensions/ob-julia/ob-julia.el
@@ -91,60 +91,23 @@
 (add-hook 'org-babel-after-execute-hook 'ek/babel-ansi)
 
 
-(define-minor-mode julia-snail-org-interaction-mode
+(define-minor-mode julia-snail-org-interaction-mode 
   "Minor mode for interacting with julia-snail through an org-mode buffer. So far this only has implemented completion inside `julia` blocks."
-  :group 'ob-julia
   :init-value nil
-  (if julia-snail-org-interaction-mode (add-hook 'completion-at-point-functions 'ob-julia-completion-at-point nil t)
-	(remove-hook 'completion-at-point-functions 'ob-julia-completion-at-point t)))
+  (cond
+   (julia-snail-org-interaction-mode
+    (add-hook 'completion-at-point-functions 'ob-julia-completion-at-point nil t)
+    (add-hook 'after-revert-hook 'julia-snail-org-interaction-mode nil t))
+   (t
+    (remove-hook 'completion-at-point-functions 'ob-julia-completion-at-point t)
+    (remove-hook 'after-revert-hook 'julia-snail-org-interaction-mode t))))
 
-
-(add-hook 'org-mode-hook 'julia-snail-org-interaction-mode)
+(add-hook 'org-mode-hook #'julia-snail-org-interaction-mode)
 
 (defun ob-julia-completion-at-point ()
   (let ((info (org-babel-get-src-block-info)))
 	(when (and info (string-equal (nth 0 info) "julia"))
-	  (let ((identifier (julia-snail--identifier-at-point))
-			(bounds (julia-snail--identifier-at-point-bounds))
-			(split-on "\\.")
-			(prefix "")
-            (module (split-string (or (cdr (assq :module (nth 2 info))) "Main") "\\."))
-			start)
-		(when bounds
-		  ;; If identifier starts with a backslash we need to add an extra "\\" to
-		  ;; make sure that the string which arrives to the completion provider on the server starts with "\\".
-		  (when (s-equals-p (substring identifier 0 1) "\\")
-			(setq prefix "\\"))
-		  ;; check if identifier at point is inside a string and attach the opening quotes so
-		  ;; we get path completion.
-		  (when-let (prev (char-before (car bounds)))
-			(when (char-equal prev ?\")
-			  (setq identifier (concat "\\\"" identifier))
-			  ;; TODO: add support for Windows paths (splitting on "\\" when appropriate)
-			  (setq split-on "/")))
-		  ;; If identifier is not a string, we split on "." so that completions of
-		  ;; the form Module.f -> Module.func work (since
-		  ;; `julia-snail--repl-completions' will return only "func" in this case)
-		  (setq start (- (cdr bounds) (length (car (last (s-split split-on identifier))))))
-		  (list start
-				(cdr bounds)
-				(completion-table-dynamic
-				 (lambda (_)
-				   (ob-julia-repl-completions (concat prefix identifier) module)
-				   ))
-				:exclusive 'no))))))
-
-(defun ob-julia-repl-completions (identifier module)
-  (let* ((res (julia-snail--send-to-server
-                :Main
-                (format "try; JuliaSnail.replcompletion(\"%1$s\", %2$s); catch; JuliaSnail.replcompletion(\"%1$s\", Main); end"
-                        identifier
-                        (s-join "." module))
-                :async nil)))
-    (if (eq :nothing res)
-        (list)
-      res)))
-
+      (julia-snail-repl-completion-at-point))))
 
 ;;; --- initialiation function
 

--- a/extensions/ob-julia/ob-julia.el
+++ b/extensions/ob-julia/ob-julia.el
@@ -37,17 +37,28 @@
   :safe 'booleanp
   :type 'boolean)
 
+(defcustom julia-snail/ob-julia-mirror-output-in-repl t
+  "If true, all output from code evaluated in ob-julia will also be shown in the julia REPL.
+Note that due to problem with async evaluation, trying to use emacs while julia code is running
+will cause your program's output to not be shown in org-mode, so this is currently a bad idea
+to disable."
+  :tag "Control the display of code evaluation in the Julia REPL"
+  :group 'julia-snail
+  :safe 'booleanp
+  :type 'boolean)
+
 
 ;;; --- implementation
 
 (defun julia-snail/ob-julia-evaluate (module _body src-file out-file)
   (let* (;;(filename (julia-snail--efn (buffer-file-name (buffer-base-buffer)))) ; commented out to make byte-compiler happy
          ;;(line-num 0)                                                          ; commented out to make byte-compiler happy
-	 (text (format "JuliaSnail.Extensions.ObJulia.babel_run_and_store(%s, \"%s\", \"%s\", %s)"
+	 (text (format "JuliaSnail.Extensions.ObJulia.babel_run_and_store(%s, \"%s\", \"%s\", %s, %s)"
 		       module
 		       src-file
 		       out-file
-		       (if julia-snail/ob-julia-use-error-pane "true" "false"))))
+		       (if julia-snail/ob-julia-use-error-pane "true" "false")
+               (if julia-snail/ob-julia-mirror-output-in-repl "true" "false"))))
     ;; This code was meant to startup julia-snail in the org buffer if it's not active, but caused an error
     ;; in org-mode on showing the first result of evalutation. Not sure why.
     ;; (unless (get-buffer julia-snail-repl-buffer)

--- a/extensions/ob-julia/ob-julia.el
+++ b/extensions/ob-julia/ob-julia.el
@@ -91,24 +91,6 @@
 (add-hook 'org-babel-after-execute-hook 'ek/babel-ansi)
 
 
-(define-minor-mode julia-snail-org-interaction-mode 
-  "Minor mode for interacting with julia-snail through an org-mode buffer. So far this only has implemented completion inside `julia` blocks."
-  :init-value nil
-  (cond
-   (julia-snail-org-interaction-mode
-    (add-hook 'completion-at-point-functions 'ob-julia-completion-at-point nil t)
-    (add-hook 'after-revert-hook 'julia-snail-org-interaction-mode nil t))
-   (t
-    (remove-hook 'completion-at-point-functions 'ob-julia-completion-at-point t)
-    (remove-hook 'after-revert-hook 'julia-snail-org-interaction-mode t))))
-
-(add-hook 'org-mode-hook #'julia-snail-org-interaction-mode)
-
-(defun ob-julia-completion-at-point ()
-  (let ((info (org-babel-get-src-block-info)))
-	(when (and info (string-equal (nth 0 info) "julia"))
-      (julia-snail-repl-completion-at-point))))
-
 ;;; --- initialiation function
 
 (defun julia-snail/ob-julia-init (repl-buf)

--- a/extensions/ob-julia/ob-julia.el
+++ b/extensions/ob-julia/ob-julia.el
@@ -78,6 +78,73 @@
 	    "Output suppressed (line too long)"
 	  bs)))))
 
+;; Deal with colour ANSI escape colour codes
+;; from https://emacs.stackexchange.com/a/63562/19896
+(defun ek/babel-ansi ()
+  (when-let ((beg (org-babel-where-is-src-block-result nil nil)))
+    (save-excursion
+      (goto-char beg)
+      (when (looking-at org-babel-result-regexp)
+        (let ((end (org-babel-result-end))
+              (ansi-color-context-region nil))
+          (ansi-color-apply-on-region beg end))))))
+(add-hook 'org-babel-after-execute-hook 'ek/babel-ansi)
+
+
+(define-minor-mode julia-snail-org-interaction-mode
+  "Minor mode for interacting with julia-snail through an org-mode buffer. So far this only has implemented completion inside `julia` blocks."
+  :group 'ob-julia
+  :init-value nil
+  (if julia-snail-org-interaction-mode (add-hook 'completion-at-point-functions 'ob-julia-completion-at-point nil t)
+	(remove-hook 'completion-at-point-functions 'ob-julia-completion-at-point t)))
+
+
+(add-hook 'org-mode-hook 'julia-snail-org-interaction-mode)
+
+(defun ob-julia-completion-at-point ()
+  (let ((info (org-babel-get-src-block-info)))
+	(when (and info (string-equal (nth 0 info) "julia"))
+	  (let ((identifier (julia-snail--identifier-at-point))
+			(bounds (julia-snail--identifier-at-point-bounds))
+			(split-on "\\.")
+			(prefix "")
+            (module (split-string (or (cdr (assq :module (nth 2 info))) "Main") "\\."))
+			start)
+		(when bounds
+		  ;; If identifier starts with a backslash we need to add an extra "\\" to
+		  ;; make sure that the string which arrives to the completion provider on the server starts with "\\".
+		  (when (s-equals-p (substring identifier 0 1) "\\")
+			(setq prefix "\\"))
+		  ;; check if identifier at point is inside a string and attach the opening quotes so
+		  ;; we get path completion.
+		  (when-let (prev (char-before (car bounds)))
+			(when (char-equal prev ?\")
+			  (setq identifier (concat "\\\"" identifier))
+			  ;; TODO: add support for Windows paths (splitting on "\\" when appropriate)
+			  (setq split-on "/")))
+		  ;; If identifier is not a string, we split on "." so that completions of
+		  ;; the form Module.f -> Module.func work (since
+		  ;; `julia-snail--repl-completions' will return only "func" in this case)
+		  (setq start (- (cdr bounds) (length (car (last (s-split split-on identifier))))))
+		  (list start
+				(cdr bounds)
+				(completion-table-dynamic
+				 (lambda (_)
+				   (ob-julia-repl-completions (concat prefix identifier) module)
+				   ))
+				:exclusive 'no))))))
+
+(defun ob-julia-repl-completions (identifier module)
+  (let* ((res (julia-snail--send-to-server
+                :Main
+                (format "try; JuliaSnail.replcompletion(\"%1$s\", %2$s); catch; JuliaSnail.replcompletion(\"%1$s\", Main); end"
+                        identifier
+                        (s-join "." module))
+                :async nil)))
+    (if (eq :nothing res)
+        (list)
+      res)))
+
 
 ;;; --- initialiation function
 

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -1047,7 +1047,7 @@ evaluated in the context of MODULE."
 ;;; --- completion implementation
 
 (defun julia-snail--repl-completions (identifier &optional module-finder)
-  (let* ((module (if module-finder (module-finder) (julia-snail--module-at-point)))
+  (let* ((module (if module-finder (apply module-finder (list)) (julia-snail--module-at-point)))
          (res (julia-snail--send-to-server
                 :Main
                 (format "try; JuliaSnail.replcompletion(\"%1$s\", %2$s); catch; JuliaSnail.replcompletion(\"%1$s\", Main); end"
@@ -1084,7 +1084,7 @@ evaluated in the context of MODULE."
       (list start
             (cdr bounds)
             (completion-table-dynamic
-             (lambda (_) (julia-snail--repl-completions (concat prefix identifier))))
+             (lambda (_) (julia-snail--repl-completions (concat prefix identifier) module-finder)))
             :exclusive 'no))))
 
 

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -1543,22 +1543,6 @@ turned on in REPL buffers."
   :lighter (:eval (julia-snail--mode-lighter " MM"))
   :keymap '(((kbd "q") . quit-window)))
 
-
-(define-minor-mode julia-snail-org-interaction-mode
-  "Minor mode for interacting with julia-snail through an org-mode buffer. So far this only has implemented completion inside `julia` blocks."
-  :group 'julia-snail
-  :init-value nil
-  (cond
-   (julia-snail-org-interaction-mode
-    (add-hook 'completion-at-point-functions 'julia-snail/ob-julia-completion-at-point nil t)
-    (add-hook 'after-revert-hook 'julia-snail-org-interaction-mode nil t))
-   (t
-    (remove-hook 'completion-at-point-functions 'julia-snail/ob-julia-completion-at-point t)
-    (remove-hook 'after-revert-hook 'julia-snail-org-interaction-mode t))))
-
-
-(add-hook 'org-mode-hook #'julia-snail-org-interaction-mode)
-
 ;;; --- done
 
 (provide 'julia-snail)

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -947,14 +947,19 @@ evaluated in the context of MODULE."
 
 (defun julia-snail--module-at-point (&optional partial-module)
   "Return the current Julia module at point as an Elisp list, including PARTIAL-MODULE if given."
-  (let ((partial-module (or partial-module
-                            (julia-snail--cst-module-at (current-buffer) (point))))
-        (module-for-file (julia-snail--module-for-file (buffer-file-name (buffer-base-buffer)))))
-    (or (if module-for-file
-            (append module-for-file partial-module)
-          partial-module)
-        '("Main"))))
-
+  (cond ((string-equal major-mode "julia-mode")
+         (let ((partial-module (or partial-module
+                                   (julia-snail--cst-module-at (current-buffer) (point))))
+               (module-for-file (julia-snail--module-for-file (buffer-file-name (buffer-base-buffer)))))
+           (or (if module-for-file
+                   (append module-for-file partial-module)
+                 partial-module)
+               '("Main"))))
+        ((string-equal major-mode "org-mode")
+         (let ((info (org-babel-get-src-block-info)))
+           (when (and info (string-equal (nth 0 info) "julia"))
+             (split-string (or (cdr (assq :module (nth 2 info))) "Main") "\\."))))
+        (t '("Main"))))
 
 ;;; --- xref implementation
 

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -1550,6 +1550,26 @@ turned on in REPL buffers."
   :keymap '(((kbd "q") . quit-window)))
 
 
+(define-minor-mode julia-snail-org-interaction-mode
+  "Minor mode for interacting with julia-snail through an org-mode buffer. So far this only has implemented completion inside `julia` blocks."
+  :group 'julia-snail
+  :init-value nil
+  (cond
+   (julia-snail-org-interaction-mode
+    (add-hook 'completion-at-point-functions 'ob-julia-completion-at-point nil t)
+    (add-hook 'after-revert-hook 'julia-snail-org-interaction-mode nil t))
+   (t
+    (remove-hook 'completion-at-point-functions 'ob-julia-completion-at-point t)
+    (remove-hook 'after-revert-hook 'julia-snail-org-interaction-mode t))))
+
+(defun ob-julia-completion-at-point ()
+  "Check if point is inside an org julia SRC block, and if so, use julia-snail repl completions"
+  (let ((info (org-babel-get-src-block-info)))
+	(when (and info (string-equal (nth 0 info) "julia"))
+      (julia-snail-repl-completion-at-point))))
+
+(add-hook 'org-mode-hook #'julia-snail-org-interaction-mode)
+
 ;;; --- done
 
 (provide 'julia-snail)


### PR DESCRIPTION
This implements the idea I suggested in https://github.com/gcv/julia-snail/pull/86#issuecomment-1100917903, it turned out to be pretty easy. 

One problem remains though, and after bashing my head against the wall, I still can't figure out the problem so I was wondering if you have any suggestions: `julia-snail-org-interaction-mode` is not automatically turning on inside org-mode buffers like it should. Rather, one still needs to explicitly do `M-x julia-snail-org-interaction-mode` but after that it appears to work great.