### PR TITLE
Inline display of results

### DIFF
--- a/JuliaSnail.jl
+++ b/JuliaSnail.jl
@@ -158,10 +158,10 @@ is equivalent to
 Main.One.Two.Three.eval(:(x = 3 + 5))
 ```
 """
-function eval_in_module(fully_qualified_module_name::Array{Symbol}, expr::Expr)
+function eval_in_module(fully_qualified_module_name::Array{Symbol}, expr::Union{Symbol,Expr})
    # Work around Julia top-level loading requirements for certain forms; also:
    # https://github.com/gcv/julia-snail/pull/78
-   if expr.head == :block
+   if isa(expr,Expr) && expr.head == :block
       expr.head = :toplevel
    end
    # Retrieving the first module in the chain can be tricky. In general, using

--- a/extensions/snail-popup/Popup.jl
+++ b/extensions/snail-popup/Popup.jl
@@ -1,0 +1,13 @@
+module Popup
+function init()
+    # initialization code can go here
+end
+
+#convert obj to text, to display in emacs popup
+function display_obj(obj)
+    io = IOBuffer();
+    show(IOContext(io,:compact=>true,:displaysize=>(10,10),:limit=>true),"text/plain",obj);
+    String(take!(io));
+end
+
+end

--- a/extensions/snail-popup/snail-popup.el
+++ b/extensions/snail-popup/snail-popup.el
@@ -1,0 +1,63 @@
+
+;;; --- requirements
+
+(require 'julia-snail)
+(require 'popup)
+
+
+;;; --- initialisation function
+
+
+
+(defun julia-snail/snail-popup-init (repl-buf)
+  (julia-snail--send-to-server
+    '("JuliaSnail" "Extensions")
+    "load([\"snail-popup\" \"Popup.jl\"]); Popup.init()"
+    :repl-buf repl-buf
+    :async nil
+    :async-poll-maximum 120000))
+
+
+;;; --- implementation
+
+
+(defun julia-snail/send-line-and-popup ()
+  "Evaluate the line at point and display its value as a popup."
+  (interactive)
+  (progn
+    (julia-snail-send-line)
+    (let* ((err (julia-snail--send-to-server
+                :Main
+                "Base.active_repl.waserror"
+                ;; line didn't run
+                :async nil))
+         (str (if (equal err :nothing) (julia-snail--send-to-server
+                              :Main
+                              "JuliaSnail.Extensions.Popup.display_obj(ans)"
+                              :async nil) "error" ))
+         )
+      (popup-tip str))))
+
+
+
+
+;;; --- extension minor-mode
+
+(defvar julia-snail/popup-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c v v") #'julia-snail/send-line-and-popup)
+    map))
+
+(define-minor-mode julia-snail/snail-popup-mode
+  "Julia Snail extension: show value in popup."
+  :init-value nil
+  :lighter ""
+  :keymap julia-snail/popup-mode-map)
+
+
+;;; --- done
+
+(provide 'julia-snail/snail-popup)
+
+
+;;; snail-popup.el ends here

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -1156,6 +1156,13 @@ This is not module-context aware."
       (user-error                       ; block fails, so send line
        (julia-snail-send-line)))))
 
+(defun julia-snail--tidy-up-error-buffer
+    ()
+  (popper--bury-all)
+  (if (buffer-live-p "*julia* error") (kill-buffer   "*julia* error") ))
+  
+
+
 (defun julia-snail-send-buffer-file ()
   "Send the current buffer's file into the Julia REPL, and include() it.
 This will occur in the context of the Main module, just as it would at the REPL."
@@ -1196,6 +1203,7 @@ This will occur in the context of the Main module, just as it would at the REPL.
                                     (pop-to-buffer error-buffer))
                                 ;; successful load
                                 (julia-snail--module-merge-includes filename includes)
+                                (julia-snail--tidy-up-error-buffer)
                                 (message "%s loaded: module %s"
                                          filename
                                          (julia-snail--construct-module-path module)))))))))


### PR DESCRIPTION
This extension implements the feature request in #90, inline display of evaluation results. I'm not sure that the way it's implemented is the right way to do it, but it gives an idea of what the functionality could be like. 

The function julia-snail/send-line-and-popup works like julia-snail-send-line, but in addition it shows the result of running the line directly in the source buffer using popul.el. It also detects errors. It is bound to C-c v v but you can also remap it to C-c C-l as a replacement for julia-snail-send-line. 

Activate by adding snail-popup to julia-snail-extensions, for instance by setting .dir-locals.el to 
```((julia-mode . ((julia-snail-extensions . (snail-popup)))))```

It should be easy to extend this to display type or size info. 

In addition, the first commit fixes a minor bug in eval_in_module. Bug is due to Meta.parse being type-unstable, i.e. 
```Meta.parse("a")```
returns a Symbol instead of an Expr. 