### PR TITLE
Only require vterm when it is the selected terminal emulator.

### DIFF
--- a/julia-snail.el
+++ b/julia-snail.el
@@ -44,7 +44,9 @@
 (require 'thingatpt)
 (require 'xref)
 
-(when (locate-library "vterm")
+(when (and (locate-library "vterm")
+           (or (not (boundp 'julia-snail-terminal-type))
+               (eq :vterm julia-snail-terminal-type)))
   (require 'vterm))
 (declare-function vterm-end-of-line "vterm.el")
 (declare-function vterm-mode "vterm.el")


### PR DESCRIPTION
This PR is to only load vterm when the `julia-snail-terminal-type` is set to `:vterm`. Currently, vterm is required as soon locate-library detects it and since vterm is a dependency of julia-snail, this is (in principle) always the case.

The current behavior is problematic, because the line `(require 'vterm)` requires compilation of 'vterm-module', which fails on my Ubuntu 18.04 machine. Since I do not intend to use it at all, I wish to disable the loading of vterm altogether.

Further, I added a rather clumsy check for whether `julia-snail-terminal-type` is bound in the if statement that surrounds `(require 'vterm)`. The variable will be bound if the user has customized it prior to loading the package, but otherwise it won't be bound until later in the file. If there is a more straightforward manner to implement this, I'll be happy to make amends.

Cheers!