### PR TITLE
Eat: don't allow reusing an existing terminal buffer

### DIFF
--- a/julia-snail.el
+++ b/julia-snail.el
@@ -653,7 +653,7 @@ Supports multiple terminal implementations."
                terml-buf))
             ;; eat
             ((eq :eat julia-snail-terminal-type)
-             (let ((terml-buf (eat launch-command)))
+             (let ((terml-buf (eat launch-command t)))
                (with-current-buffer terml-buf
                  (rename-buffer julia-snail-repl-buffer))
                terml-buf))

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -653,11 +653,10 @@ Supports multiple terminal implementations."
                terml-buf))
             ;; eat
             ((eq :eat julia-snail-terminal-type)
-             (let ((terml-buf (eat launch-command t)))
-               (with-current-buffer source-buf
-                 (let ((repl-buffer-name julia-snail-repl-buffer))
-                   (with-current-buffer terml-buf
-                     (rename-buffer repl-buffer-name))))
+             (let ((terml-buf (eat launch-command t))
+                   (repl-buffer-name julia-snail-repl-buffer))
+               (with-current-buffer terml-buf
+                 (rename-buffer repl-buffer-name))
                terml-buf))
             ;; unsupported value
             (t

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -654,8 +654,10 @@ Supports multiple terminal implementations."
             ;; eat
             ((eq :eat julia-snail-terminal-type)
              (let ((terml-buf (eat launch-command t)))
-               (with-current-buffer terml-buf
-                 (rename-buffer julia-snail-repl-buffer))
+               (with-current-buffer source-buf
+                 (let ((repl-buffer-name julia-snail-repl-buffer))
+                   (with-current-buffer terml-buf
+                     (rename-buffer repl-buffer-name))))
                terml-buf))
             ;; unsupported value
             (t


### PR DESCRIPTION
Closes #133

Passing the prefix argument to `eat` forces creating a new session.

There was also a problem with reading the buffer-local value of `julia-snail-repl-buffer` that the vterm path avoids.  I think it's because in that branch the current buffer is still the source when the vterm buffer is created.  This isn't a problem with the port number because the launch command is formed similarly.  It is possible to create an Eat process inside one's own buffer like you do for vterm (see the `eat-exec` call in `eat--1`) but that would involve copying probably the entire block at https://codeberg.org/akib/emacs-eat/src/commit/5aaad960c8f0caa2bc4c8b2f9da4dc0c809550fe/eat.el#L7057.

Let me know if you'd prefer a different solution. 