### PR TITLE
Skip completion at point if there is no REPL buffer

### DIFF
--- a/julia-snail.el
+++ b/julia-snail.el
@@ -1345,10 +1345,11 @@ evaluated in the context of MODULE."
   "Implementation for Emacs `completion-at-point' system using REPL.REPLCompletions as the provider."
   (let ((identifier (julia-snail--identifier-at-point))
         (bounds (julia-snail--identifier-at-point-bounds))
+        (repl-buf (get-buffer julia-snail-repl-buffer))
         (split-on "\\.")
         (prefix "")
         start)
-    (when bounds
+    (when (and bounds repl-buf)
       ;; If identifier starts with a backslash we need to add an extra "\\" to
       ;; make sure that the string which arrives to the completion provider on the server starts with "\\".
       (when (s-equals-p (substring identifier 0 1) "\\")


### PR DESCRIPTION
If the `completion-at-point` system is triggered, but there is no REPL buffer, the `julia-snail-repl-completion-at-point` function still attempts to communicate with the REPL buffer, yielding the following message:

    completion--some: No Julia REPL buffer *julia* found; run
    julia-snail

Unfortunately, no other `completion-at-point-functions` are allowed to attempt completion, so no completion is performed, even if later entries in `completion-at-point-functions` could have handled it (e.g., the ones provided by `julia-mode`).

The documentation for `completion-at-point-functions` says to return `nil` if the completion function is not applicable. This commit changes `julia-snail-repl-completion-at-point` to check that the REPL buffer exists, and if it doesn't, it returns `nil`, allowing other `completion-at-point-functions` to take a turn.