### PR TITLE
Set configurable resource directory for ob-julia extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ Customization variables:
 - `julia-snail/ob-julia-use-error-pane t` : If true, use julia-snail's popup error pane. Otherwise, display errors inline
 - `julia-snail/ob-julia-mirror-output-in-repl t` : If true, all output from code evaluated in ob-julia will also be shown in the julia REPL.
 - `julia-snail/ob-julia-capture-io t` : If true, all intermediate printing during evaluation will be captured by ob-julia and printed into your org notebook
-- `org-babel-julia-snail-resource-directory "./.ob-julia-snail/"`: Directory used to store automatically generated image files for display in org buffers. By default this is a local hidden directory, but it can be changed to e.g. `/tmp/` if you don't want to keep the image files around.
+- `julia-snail/ob-julia-resource-directory "./.ob-julia-snail/"`: Directory used to store automatically generated image files for display in org buffers. By default this is a local hidden directory, but it can be changed to e.g. `/tmp/` if you don't want to keep the image files around.
 
 
 ## Future improvements

--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ Customization variables:
 - `julia-snail/ob-julia-use-error-pane t` : If true, use julia-snail's popup error pane. Otherwise, display errors inline
 - `julia-snail/ob-julia-mirror-output-in-repl t` : If true, all output from code evaluated in ob-julia will also be shown in the julia REPL.
 - `julia-snail/ob-julia-capture-io t` : If true, all intermediate printing during evaluation will be captured by ob-julia and printed into your org notebook
+- `org-babel-julia-snail-resource-directory "./.ob-julia-snail/"`: Directory used to store automatically generated image files for display in org buffers. By default this is a local hidden directory, but it can be changed to e.g. `/tmp/` if you don't want to keep the image files around.
 
 
 ## Future improvements

--- a/extensions/ob-julia/ob-julia.el
+++ b/extensions/ob-julia/ob-julia.el
@@ -53,6 +53,11 @@ your org notebook"
   :safe 'booleanp
   :type 'boolean)
 
+(defcustom org-babel-julia-snail-resource-directory "./.ob-julia-snail/"
+  "Directory used to store automatically generated image files for display in org buffers."
+  :group 'julia-snail
+  :type 'string)
+
 (defvar julia-snail/ob-julia--point-inits (make-hash-table))
 (defvar julia-snail/ob-julia--point-finals (make-hash-table))
 
@@ -62,10 +67,11 @@ your org notebook"
 (defun julia-snail/ob-julia-evaluate (module _body src-file out-file)
   (let* (;;(filename (julia-snail--efn (buffer-file-name (buffer-base-buffer)))) ; commented out to make byte-compiler happy
          ;;(line-num 0)                                                          ; commented out to make byte-compiler happy
-         (text (format "JuliaSnail.Extensions.ObJulia.babel_run_and_store(%s, \"%s\", \"%s\", %s, %s, %s)"
+         (text (format "JuliaSnail.Extensions.ObJulia.babel_run_and_store(%s, \"%s\", \"%s\", \"%s\", %s, %s, %s)"
                        module
                        src-file
                        out-file
+                       org-babel-julia-snail-resource-directory
                        (if julia-snail/ob-julia-use-error-pane "true" "false")
                        (if julia-snail/ob-julia-mirror-output-in-repl "true" "false")
                        (if julia-snail/ob-julia-capture-io "true" "false"))))

--- a/extensions/ob-julia/ob-julia.el
+++ b/extensions/ob-julia/ob-julia.el
@@ -53,7 +53,7 @@ your org notebook"
   :safe 'booleanp
   :type 'boolean)
 
-(defcustom org-babel-julia-snail-resource-directory "./.ob-julia-snail/"
+(defcustom julia-snail/ob-julia-resource-directory "./.ob-julia-snail/"
   "Directory used to store automatically generated image files for display in org buffers."
   :group 'julia-snail
   :type 'string)
@@ -71,7 +71,7 @@ your org notebook"
                        module
                        src-file
                        out-file
-                       org-babel-julia-snail-resource-directory
+                       julia-snail/ob-julia-resource-directory
                        (if julia-snail/ob-julia-use-error-pane "true" "false")
                        (if julia-snail/ob-julia-mirror-output-in-repl "true" "false")
                        (if julia-snail/ob-julia-capture-io "true" "false"))))

--- a/extensions/ob-julia/src/ObJulia.jl
+++ b/extensions/ob-julia/src/ObJulia.jl
@@ -21,7 +21,7 @@ function maybe_redirect_stderr_stdout(f, io, flag)
     end
 end
 
-function babel_run_and_store(mod::Module, src_file, out_file,
+function babel_run_and_store(mod::Module, src_file, out_file, resource_directory,
                              use_error_pane::Bool,
                              mirror_to_repl::Bool,
                              capture_io::Bool)
@@ -43,7 +43,7 @@ function babel_run_and_store(mod::Module, src_file, out_file,
             Base.invokelatest() do
                 for (imgtype, ext) ∈ [("image/png", ".png"), ("image/svg+xml", ".svg")]
                     if showable(imgtype, result)
-                        tmp = tempname() * ext
+                        tmp = tempname(mkpath(resource_directory); cleanup=false) * ext
                         open(tmp, "w+") do io
                             show(io, imgtype, result) # Save the image to disk
                         end


### PR DESCRIPTION
This lets users customize where images are saved. By default it's a local hidden folder, but users can set it to e.g. `/tmp/` or whatever if they don't want to keep these images around. 