### PR TITLE
Fix CSTParser dep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,4 +2,4 @@
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
 
 [compat]
-CSTParser = "~3.3.0"
+CSTParser = "3.3.0"


### PR DESCRIPTION
The project is currently set to `"~3.3.0"`, but this unnecessarily restricts CSTParser to a version that's broken in julia v1.11. 

Unless there's a very good reason to do so, the preferred thing is to trust that package authors are following semantic versioning, and won't release a `v3.4` that breaks existing APIs. In this case, `3.4` adjusts to accommodate the fact that the 3.3 was broken on julia v1.11. 