### PR TITLE
Remove `eat-reload` workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,7 @@ Eat requires Emacs 28.1 or later. Install and configure it. The following `use-p
   (delete [?\C-u] eat-semi-char-non-bound-keys) ; make C-u work in Eat terminals like in normal terminals
   (delete [?\C-g] eat-semi-char-non-bound-keys) ; ditto for C-g
   (eat-update-semi-char-mode-map)
-  ;; XXX: Awkward workaround for the need to call eat-reload after changing Eat's keymaps,
-  ;; but reloading from :config section causes infinite recursion because :config wraps with-eval-after-load.
-  (defvar eat--prevent-use-package-config-recursion nil)
-  (unless eat--prevent-use-package-config-recursion
-    (setq eat--prevent-use-package-config-recursion t)
-    (eat-reload))
-  (makunbound 'eat--prevent-use-package-config-recursion)
-  )
+  (eat-reload))
 ```
 
 


### PR DESCRIPTION
I believe this workaround is no longer necessary after [this change](https://codeberg.org/akib/emacs-eat/commit/64dcbd2c072a601dd9d152324cb4c5632b06741d).