### PR TITLE
Fix #117: Support bootstrap on read-only installations (e.g., Nix store)

### DIFF
--- a/JuliaSnail.jl
+++ b/JuliaSnail.jl
@@ -16,6 +16,24 @@ import Pkg
 
 module JuliaSnail
 
+function pkg_env_for_bootstrap(dir)
+   if iswritable(dir)
+      return dir
+   end
+   env_name = "julia-snail-" * string(hash(abspath(dir)), base=16)
+   cache = joinpath(first(Base.DEPOT_PATH), "environments", env_name)
+   mkpath(cache)
+   cp(joinpath(dir, "Project.toml"), joinpath(cache, "Project.toml"); force=true)
+   let manifest_src = joinpath(dir, "Manifest.toml")
+      isfile(manifest_src) && cp(manifest_src, joinpath(cache, "Manifest.toml"); force=true)
+   end
+   cache
+end
+
+bootstrap_required(err) =
+   isa(err, ArgumentError) ||
+   (isa(err, LoadError) && isa(err.error, ArgumentError))
+
 
 # XXX: External dependency hack. Snail's own dependencies need to be listed
 # first in LOAD_PATH during initial load, otherwise conflicting versions
@@ -24,27 +42,33 @@ module JuliaSnail
 # the rest of the time.
 macro with_pkg_env(dir, action)
    :(
-   try
-      insert!(LOAD_PATH, 1, $dir)
-      $action
-   catch err
-      if isa(err, ArgumentError)
-         if isfile(joinpath($dir, "Project.toml"))
+   let _snail_prev_project = Base.active_project(),
+       _snail_pkg_env = Main.JuliaSnail.pkg_env_for_bootstrap($dir)
+      try
+         insert!(LOAD_PATH, 1, _snail_pkg_env)
+         Main.Pkg.activate(_snail_pkg_env)
+         $action
+      catch err
+         if Main.JuliaSnail.bootstrap_required(err) && isfile(joinpath(_snail_pkg_env, "Project.toml"))
             # force dependency installation
-            Main.Pkg.activate($dir)
+            Main.Pkg.activate(_snail_pkg_env)
             Main.Pkg.instantiate()
             Main.Pkg.precompile()
-            # activate what was the first entry before Snail was pushed to the head of LOAD_PATH
-            Main.Pkg.activate(LOAD_PATH[2])
+            $action
+         else
+            rethrow(err)
          end
-      end
-   finally
-      # Remove Snail from the head of the LOAD_PATH and put it at the tail. At this
-      # point, all of its own dependencies should be loaded and the user's
-      # preferred project should be active.
-      deleteat!(LOAD_PATH, 1)
-      if isfile(joinpath($dir, "Project.toml"))
-         push!(LOAD_PATH, $dir)
+      finally
+         # Remove Snail from the head of the LOAD_PATH and put it at the tail. At this
+         # point, all of its own dependencies should be loaded and the user's
+         # preferred project should be active.
+         deleteat!(LOAD_PATH, 1)
+         if isfile(joinpath(_snail_pkg_env, "Project.toml"))
+            push!(LOAD_PATH, _snail_pkg_env)
+         end
+         if !isnothing(_snail_prev_project)
+            Main.Pkg.activate(dirname(_snail_prev_project))
+         end
       end
    end
    )

--- a/JuliaSnail.jl
+++ b/JuliaSnail.jl
@@ -43,18 +43,18 @@ bootstrap_required(err) =
 macro with_pkg_env(dir, action)
    :(
    let _snail_prev_project = Base.active_project(),
-       _snail_pkg_env = Main.JuliaSnail.pkg_env_for_bootstrap($dir)
+       _snail_pkg_env = Main.JuliaSnail.pkg_env_for_bootstrap($(esc(dir)))
       try
          insert!(LOAD_PATH, 1, _snail_pkg_env)
          Main.Pkg.activate(_snail_pkg_env)
-         $action
+         $(esc(action))
       catch err
          if Main.JuliaSnail.bootstrap_required(err) && isfile(joinpath(_snail_pkg_env, "Project.toml"))
             # force dependency installation
             Main.Pkg.activate(_snail_pkg_env)
             Main.Pkg.instantiate()
             Main.Pkg.precompile()
-            $action
+            $(esc(action))
          else
             rethrow(err)
          end

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -580,7 +580,7 @@ Returns nil if the poll timed out, t otherwise."
                                    buffer-file-coding-system))))
     (base64-encode-string s)))
 
-(defun julia-snail--copy-snail-to-remote-host ()
+(defun julia-snail--stage-julia-runtime ()
   (let* (;; checksum all relevant files as one, copy into a directory
          ;; keyed off the checksum if it doesn't already exist (basically cache
          ;; the current version of the Julia code (.jl and .toml files)
@@ -589,16 +589,23 @@ Returns nil if the poll timed out, t otherwise."
                               (when (file-regular-p f)
                                 (insert-file-contents-literally f)))
                      (secure-hash 'sha256 (current-buffer))))
-         (snail-remote-dir (concat (file-name-as-directory (temporary-file-directory))
-                                   (concat "julia-snail-" checksum "/"))))
-    (unless (file-exists-p snail-remote-dir)
-      (make-directory snail-remote-dir)
+         (staged-runtime-dir (concat (file-name-as-directory (temporary-file-directory))
+                                     (concat "julia-snail-" checksum "/")))
+         (staged-server-file (concat staged-runtime-dir "JuliaSnail.jl")))
+    (unless (file-exists-p staged-server-file)
+      (when (file-exists-p staged-runtime-dir)
+        (delete-directory staged-runtime-dir t))
+      (make-directory staged-runtime-dir t)
       (let ((default-directory (file-name-directory (locate-library "julia-snail"))))
         (cl-loop for f in julia-snail--julia-files do
                  (if (file-directory-p f)
-                     (make-directory (concat snail-remote-dir f))
-                   (copy-file (file-truename f) (concat snail-remote-dir (file-name-directory f)) t)))))
-    snail-remote-dir))
+                     (make-directory (concat staged-runtime-dir f) t)
+                    (copy-file (file-truename f) (concat staged-runtime-dir (file-name-directory f)) t)))))
+    staged-runtime-dir))
+
+(defun julia-snail--local-runtime-needs-staging-p ()
+  "Return non-nil when the installed Julia runtime directory is not writable."
+  (not (file-writable-p (file-name-directory julia-snail--server-file))))
 
 (defun julia-snail--launch-command ()
   (let* ((extra-args (if (listp julia-snail-extra-args)
@@ -607,13 +614,19 @@ Returns nil if the poll timed out, t otherwise."
 	 (remote-method (file-remote-p default-directory 'method))
          (remote-user (file-remote-p default-directory 'user))
          (remote-host (file-remote-p default-directory 'host))
-	 (remote-dir-server-file (if (equal nil remote-method)
-				     ""
-				   (concat (file-remote-p (julia-snail--copy-snail-to-remote-host) 'localname) "JuliaSnail.jl"))))
+	 (staged-runtime-dir (when (or remote-method
+                                      (julia-snail--local-runtime-needs-staging-p))
+                              (julia-snail--stage-julia-runtime)))
+         (server-file (if staged-runtime-dir
+                          (let ((staged-server-file (concat staged-runtime-dir "JuliaSnail.jl")))
+                            (if remote-method
+                                (file-remote-p staged-server-file 'localname)
+                              staged-server-file))
+                        julia-snail--server-file)))
     (cond
      ;; local REPL
      ((equal nil remote-method)
-      (format "%s -i %s -L %s" julia-snail-executable extra-args julia-snail--server-file))
+      (format "%s -i %s -L %s" julia-snail-executable extra-args server-file))
      ;; remote REPL
      ((or (string-equal "ssh" remote-method)
           (string-equal "sshx" remote-method)
@@ -625,16 +638,16 @@ Returns nil if the poll timed out, t otherwise."
               (concat
                (if remote-user (concat remote-user "@") "")
                remote-host)
-              julia-snail-executable
-              extra-args
-              remote-dir-server-file))
+               julia-snail-executable
+               extra-args
+               server-file))
      ;; container REPL
      ((string-equal "docker" remote-method)
       (format "docker exec -it %s %s %s -L %s"
 	      remote-host
 	      julia-snail-executable
 	      extra-args
-	      remote-dir-server-file))
+	      server-file))
      ;; unsupported method
      (t
       (user-error "Unsupported Tramp method %s" remote-method)))))


### PR DESCRIPTION
This PR fixes #117 by generalizing Snail's existing staged Julia runtime mechanism, which was previously used for remote REPLs, and reusing it for read-only local installations. When the installed Julia runtime directory is not writable, local startup launches Julia with `-L` pointing at a writable checksum-keyed staged copy.

Fixes #117