### PR TITLE
Add ghostel as a terminal backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Snail is a development environment and REPL interaction package for Julia in the spirit of Common Lisp’s [SLIME](https://common-lisp.net/project/slime/) and Clojure’s [CIDER](https://cider.mx). It enables convenient and dynamic REPL-driven development.
 
-Snail works on platforms which support [libvterm](https://github.com/neovim/libvterm) or [Eat](https://codeberg.org/akib/emacs-eat), which currently means Unix-like systems. It should also work on Windows using [WSL](https://docs.microsoft.com/en-us/windows/wsl/about).
+Snail works on platforms which support [libvterm](https://github.com/neovim/libvterm), [Eat](https://codeberg.org/akib/emacs-eat), or [ghostel](https://github.com/dakra/ghostel), which currently means Unix-like systems. It should also work on Windows using [WSL](https://docs.microsoft.com/en-us/windows/wsl/about).
 
 Refer to the [changelog](https://github.com/gcv/julia-snail/blob/master/CHANGELOG.md) for release notes.
 
@@ -46,7 +46,7 @@ Refer to the [changelog](https://github.com/gcv/julia-snail/blob/master/CHANGELO
 
 ## Features
 
-- **REPL display:** Snail uses advanced terminal emulators ([libvterm](https://github.com/neovim/libvterm) with [Emacs bindings](https://github.com/akermu/emacs-libvterm) or [Eat](https://codeberg.org/akib/emacs-eat)) to display Julia’s native REPL. As a result, the REPL has good performance and far fewer display glitches than attempting to run the REPL in an Emacs-native `term.el` buffer.
+- **REPL display:** Snail uses advanced terminal emulators ([libvterm](https://github.com/neovim/libvterm) with [Emacs bindings](https://github.com/akermu/emacs-libvterm), [Eat](https://codeberg.org/akib/emacs-eat)), or [ghostel](https://github.com/dakra/ghostel) to display Julia’s native REPL. As a result, the REPL has good performance and far fewer display glitches than attempting to run the REPL in an Emacs-native `term.el` buffer.
 - **REPL interaction:** Snail provides a bridge between Julia code and a Julia process running in a REPL. The bridge allows Emacs to interact with and introspect the Julia image. Among other things, this allows loading entire files and individual functions into running Julia processes.
 - **Remote REPLs:** Julia sessions on remote machines work transparently with Snail using SSH and Emacs Tramp.
 - **Multimedia and plotting:** Snail can display Julia graphics in graphical Emacs instances using packages like [Plots](http://juliaplots.org) and [Gadfly](http://gadflyjl.org).
@@ -66,7 +66,7 @@ Julia versions >1.6.0 should all work with Snail.
 
 Snail’s Julia-side dependencies will automatically be installed when it starts, and will stay out of your way using Julia’s [`LOAD_PATH` mechanism](https://docs.julialang.org/en/v1/base/constants/#Base.LOAD_PATH).
 
-On the Emacs side, you must install one of the supported high-performance terminal emulators to use with the Julia REPL: either `vterm` or [Eat](https://codeberg.org/akib/emacs-eat).
+On the Emacs side, you must install one of the supported high-performance terminal emulators to use with the Julia REPL: `vterm`, [Eat](https://codeberg.org/akib/emacs-eat), or [ghostel](https://github.com/dakra/ghostel).
 
 
 ### `vterm`
@@ -101,6 +101,11 @@ Eat requires Emacs 28.1 or later. Install and configure it. The following `use-p
   (makunbound 'eat--prevent-use-package-config-recursion)
   )
 ```
+
+### Ghostel
+
+1. Install [ghostel](https://github.com/dakra/ghostel) using your Emacs package manager. It is available from [MELPA](https://melpa.org/#/ghostel), so use something like `(package-install 'ghostel)` or `(use-package ghostel :ensure t)`.
+2. Verify that `ghostel` works by running `M-x ghostel` to start a shell. It should display a nice terminal buffer. You may find it useful to customize and configure `ghostel`.
 
 
 ### Snail
@@ -140,6 +145,18 @@ To use Eat instead of `vterm`, set `julia-snail-terminal-type` to `:eat`:
   (julia-snail-terminal-type :eat)
   :hook
   (julia-mode . julia-snail-mode))
+```
+
+To use ghostel instead, set `julia-snail-terminal-type` to `:ghostel`:
+
+```elisp
+(use-package julia-snail
+  :ensure t
+  :custom
+  (julia-snail-terminal-type :ghostel)
+  :hook
+  (julia-mode . julia-snail-mode)
+  :after ghostel)
 ```
 
 

--- a/julia-snail.el
+++ b/julia-snail.el
@@ -44,7 +44,7 @@
 (require 'thingatpt)
 (require 'xref)
 
-;; XXX: One of vterm or eat must be manually installed before Snail starts.
+;; XXX: One of vterm, eat, or ghostel must be manually installed before Snail starts.
 ;; Picking one or the other involves tradeoffs best left to the user, and
 ;; therefore neither is added to the Package-Requires header. Briefly, vterm
 ;; supports older versions of Emacs (down to 26) but has more complicated module
@@ -52,8 +52,9 @@
 ;; two emulate terminals differently, and so one may be preferable to the other
 ;; for other reasons.
 (when (not (or (locate-library "vterm")
-               (locate-library "eat")))
-  (user-error "Neither vterm nor eat dependencies detected; please install one or the other"))
+               (locate-library "eat")
+               (locate-library "ghostel")))
+  (user-error "Neither vterm, eat, nor ghostel dependencies detected; please install one"))
 
 (when (locate-library "vterm")
   (require 'vterm))
@@ -70,6 +71,14 @@
 (declare-function eat-self-input "eat.el")
 (defvar eat-terminal)
 
+(when (locate-library "ghostel")
+  (require 'ghostel))
+(declare-function ghostel "ghostel.el")
+(declare-function ghostel-send-string "ghostel.el")
+(declare-function ghostel-send-key "ghostel.el")
+(declare-function ghostel-readonly-end-of-line "ghostel.el")
+(defvar ghostel-shell)
+(defvar ghostel-buffer-name)
 
 ;;; --- customizations
 
@@ -121,14 +130,20 @@
 (make-variable-buffer-local 'julia-snail-repl-buffer)
 
 (defcustom julia-snail-terminal-type
-  (if (locate-library "vterm") :vterm :eat) ; default to :vterm for historical compatibility
+  ;; default to :vterm for historical compatibility
+  (cond
+   ((locate-library "vterm") :vterm)
+   ((locate-library "eat") :eat)
+   ((locate-library "ghostel") :ghostel)
+   (t :vterm))
   "Which Emacs terminal emulator to use for the Julia REPL."
   :tag "Terminal type"
   :group 'julia-snail
-  :options '(:eat :vterm)
-  :safe (lambda (v) (memq v '(:eat :vterm)))
+  :options '(:eat :vterm :ghostel)
+  :safe (lambda (v) (memq v '(:eat :vterm :ghostel)))
   :type '(choice (const :tag "Eat" :eat)
-                 (const :tag "vterm" :vterm)))
+                 (const :tag "vterm" :vterm)
+                 (const :tag "ghostel" :ghostel)))
 ;;(make-variable-buffer-local 'julia-snail-terminal-type) ; XXX: Let's not make this a buffer-local switch. Too messy.
 
 (defcustom julia-snail-show-error-window t
@@ -715,6 +730,19 @@ Supports multiple terminal implementations."
                (with-current-buffer terml-buf
                  (rename-buffer repl-buffer-name))
                terml-buf))
+            ;; ghostel
+            ((eq :ghostel julia-snail-terminal-type)
+             (let* ((command-and-args (split-string-and-unquote launch-command))
+                    (command (executable-find (seq-first command-and-args)))
+                    (args (seq-rest command-and-args))
+                    (buffer (generate-new-buffer julia-snail-repl-buffer)))
+               (pop-to-buffer buffer)
+               (ghostel-exec buffer command args)
+               ;; Prevent ghostel's title tracking logic from messing up our
+               ;; buffer name.
+               (with-current-buffer buffer
+                 (setq-local ghostel-buffer-name-function nil))
+               buffer))
             ;; unsupported value
             (t
              (user-error "unsupported value for julia-snail-terminal-type: %s" julia-snail-terminal-type)))))
@@ -949,6 +977,9 @@ returns \"/home/username/file.jl\"."
    ;; vterm
    ((eq 'vterm-mode major-mode)
     (vterm-send-string str))
+   ;; ghostel
+   ((eq 'ghostel-mode major-mode)
+    (ghostel-send-string str))
    ;; error and debugging
    (t
     (error "function called out of context; (with-current-buffer repl-buf ...) required"))))
@@ -965,12 +996,23 @@ returns \"/home/username/file.jl\"."
    ;; vterm
    ((eq 'vterm-mode major-mode)
     (vterm-send-return))
+   ;; ghostel
+   ((eq 'ghostel-mode major-mode)
+    (ghostel-send-key "return"))
    ;; error and debugging
    (t
     (error "function called out of context; (with-current-buffer repl-buf ...) required"))))
 
 
 ;;; --- Julia REPL and Snail server interaction functions
+
+(defun julia-snail--looking-back-string (str)
+  "Return t if the buffer contents preceding point matches `str'. The same
+as `looking-back', but for string matches instead of regular expression
+matches."
+  (string-equal str
+                (buffer-substring-no-properties (- (point) (length str))
+                                                (point))))
 
 (cl-defun julia-snail--send-to-repl
     (str
@@ -996,7 +1038,7 @@ wait for the REPL prompt to return, otherwise return immediately."
       ;; wait for the inclusion to succeed (i.e., the prompt prints)
       (julia-snail--wait-while
        (with-current-buffer repl-buf
-         (not (string-equal "julia>" (current-word))))
+         (not (julia-snail--looking-back-string "julia> ")))
        polling-interval
        polling-timeout))))
 
@@ -1975,6 +2017,18 @@ This will occur in the context of the Main module, just as it would at the REPL.
    ((eq 'vterm-mode major-mode)
     (kill-ring-save (point) (vterm-end-of-line))
     (vterm-send-key "k" nil nil t))
+   ;; ghostel
+   ((eq 'ghostel-mode major-mode)
+    (if buffer-read-only
+        ;; When a ghostel buffer is in emacs input mode or copy input mode, the
+        ;; buffer is marked as read only, and C-k is bound to the usual
+        ;; `kill-line', so we'll do the same here.
+        (kill-line)
+      ;; Otherwise, it is in a terminal-like mode, so we put content on the yank
+      ;; ring and then send the C-k key.
+      (progn
+        (kill-ring-save (point) (line-end-position))
+        (ghostel-send-key "k" "ctrl"))))
    ;; error and debugging
    (t
     (error "function called out of context; (with-current-buffer repl-buf ...) required"))))
@@ -2128,7 +2182,9 @@ The following keys are set:
   :init-value nil
   :lighter (:eval (julia-snail--mode-lighter))
   :keymap julia-snail-repl-mode-map
-  (when (or (eq 'vterm-mode major-mode) (eq 'eat-mode major-mode))
+  (when (or (eq 'vterm-mode major-mode)
+            (eq 'eat-mode major-mode)
+            (eq 'ghostel-mode major-mode))
     (if julia-snail-repl-mode
         (julia-snail--repl-enable)
       (julia-snail--repl-disable))))


### PR DESCRIPTION
[Ghostel](https://github.com/dakra/ghostel) is a new Emacs terminal package built on libghostty. It claims to be more performant than libvterm while offering a richer set of terminal features. This PR adds it as another terminal backend option for Snail.

I've only done some limited manual testing with it, and it seems to work well. But I haven't used it extensively for my day-to-day work, yet.